### PR TITLE
Continuum redirect fix and add docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+## This is only a single container right now but in future this should bring up supporting services needed for development ie: postgres, audit service ect.
+version: '3'
+services:
+  application:
+    image: node:10
+    ports:
+      - "${CONTINUUM_LOGIN_PORT:-3003}:3003"
+    working_dir: "/src"
+    command: ["bash", "-c", "yarn && yarn run start:dev"]
+    healthcheck:
+      test: "curl localhost:3003/health"
+      interval: 1m
+      timeout: 10s
+      retries: 3
+    environment:
+      PORT: "3003"
+      CONTINUUM_LOGIN_JWT_SECRET: "${AUTHENTICATION_JWT_SECRET}"
+      CONTINUUM_LOGIN_REDIRECT_URL: "${AUTHENTICATION_URL}"
+    volumes:
+      - ./:/src/:z
+    networks:
+      - infra_api
+
+networks:
+  infra_api:
+    external:
+      name: "infra_api"

--- a/src/use-cases/journalSubmit.test.ts
+++ b/src/use-cases/journalSubmit.test.ts
@@ -18,6 +18,6 @@ describe('submit', () => {
 
         expect(sign).toHaveBeenCalledTimes(1);
         expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
-        expect(mockResponse.redirect).toHaveBeenCalledWith('http://authurl/authenticate/signed_jwt_token');
+        expect(mockResponse.redirect).toHaveBeenCalledWith('http://authurl/authenticate#signed_jwt_token');
     });
 });

--- a/src/use-cases/journalSubmit.ts
+++ b/src/use-cases/journalSubmit.ts
@@ -9,7 +9,6 @@ export const JournalSubmit = (config: ConfigType, sign) => (req: Request, resp: 
 
     const redirectUrl =
         config.continuumLoginRedirectUrl +
-        // (config.continuumLoginRedirectUrl && config.continuumLoginRedirectUrl.endsWith('/') ? '' : '/') +
         '#' +
         token;
 

--- a/src/use-cases/journalSubmit.ts
+++ b/src/use-cases/journalSubmit.ts
@@ -9,7 +9,8 @@ export const JournalSubmit = (config: ConfigType, sign) => (req: Request, resp: 
 
     const redirectUrl =
         config.continuumLoginRedirectUrl +
-        (config.continuumLoginRedirectUrl && config.continuumLoginRedirectUrl.endsWith('/') ? '' : '/') +
+        // (config.continuumLoginRedirectUrl && config.continuumLoginRedirectUrl.endsWith('/') ? '' : '/') +
+        '#' +
         token;
 
     resp.redirect(redirectUrl);

--- a/src/use-cases/journalSubmit.ts
+++ b/src/use-cases/journalSubmit.ts
@@ -7,10 +7,7 @@ export const JournalSubmit = (config: ConfigType, sign) => (req: Request, resp: 
         expiresIn: '1d',
     });
 
-    const redirectUrl =
-        config.continuumLoginRedirectUrl +
-        '#' +
-        token;
+    const redirectUrl = `${config.continuumLoginRedirectUrl}#${token}`;
 
     resp.redirect(redirectUrl);
 };


### PR DESCRIPTION
The journal does not redirect to a http://<redirect-url>/<token>, it redirects with a hash pattern:
http://<redirect-url>#<token> instead.

This PR updates the behaviour to return with a hash and also adds a docker-compose.yml for local development