### PR TITLE
27 - add getSubmission to resolver

### DIFF
--- a/src/mock-graphql/resolvers.ts
+++ b/src/mock-graphql/resolvers.ts
@@ -1,4 +1,4 @@
-import { getSubmissions, startSubmission, getCurrentUser } from '../use-cases';
+import { getSubmissions, startSubmission, getCurrentUser, getSubmission } from '../use-cases';
 
 const submissions = [];
 
@@ -6,6 +6,7 @@ export const resolvers = {
     Query: {
         getCurrentUser: getCurrentUser(),
         getSubmissions: getSubmissions(submissions),
+        getSubmission: getSubmission(submissions),
     },
     Mutation: {
         startSubmission: startSubmission(submissions),

--- a/src/use-cases/getSubmission.test.ts
+++ b/src/use-cases/getSubmission.test.ts
@@ -1,0 +1,14 @@
+import { getSubmission } from './getSubmission';
+
+describe('getSubmission', (): void => {
+    it('returns the submission with correct id', (): void => {
+        const submissions = [{ id: 'A' }, { id: 'B' }];
+        expect(getSubmission(submissions)('A')).toStrictEqual({ id: 'A' });
+        expect(getSubmission(submissions)('B')).toStrictEqual({ id: 'B' });
+    });
+    it('throws error if no submission is found', (): void => {
+        expect((): void => {
+            getSubmission([])('A');
+        }).toThrow('could not find submission with id: A');
+    });
+});

--- a/src/use-cases/getSubmission.ts
+++ b/src/use-cases/getSubmission.ts
@@ -1,3 +1,7 @@
-export const getSubmission = (submissions: {}): (() => Array<{}>) => () => {
-    return submissions[0];
+export const getSubmission = (submissions: Array<{ id: string }>): ((id: string) => {}) => (id): {} => {
+    const submissionIndex = submissions.findIndex(submission => submission.id === id);
+    if (submissionIndex !== -1) {
+        return submissions[submissionIndex];
+    }
+    throw new Error('could not find submission with id: ' + id);
 };

--- a/src/use-cases/index.ts
+++ b/src/use-cases/index.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 export * from './journalSubmit';
 export * from './authenticate';
 export * from './getSubmissions';
+export * from './getSubmission';
 export * from './startSubmission';
 export * from './getProfile';
 export * from './getPerson';


### PR DESCRIPTION
Creates a working stub for fetching a submission by id. Adds getSubmission to the graphql resolver.

closes #27 