### PR TITLE
make return of deleteSubmission submission id

### DIFF
--- a/src/mock-graphql/typeDefs.ts
+++ b/src/mock-graphql/typeDefs.ts
@@ -22,6 +22,6 @@ export const typeDefs = gql`
     type Mutation {
         startSubmission(articleType: String!): Submission!
         changeSubmissionTitle(id: ID!, title: String!): Submission!
-        deleteSubmission(id: ID!): Boolean
+        deleteSubmission(id: ID!): ID
     }
 `;

--- a/src/use-cases/deleteSubmission.test.ts
+++ b/src/use-cases/deleteSubmission.test.ts
@@ -8,12 +8,12 @@ describe('deleteSubmission', (): void => {
         expect(submissions).toHaveLength(1);
         expect(submissions[0]).toStrictEqual({ id: 'B' });
     });
-    it('returns true when it has deleted a submission', (): void => {
+    it('returns id when it has deleted a submission', (): void => {
         const submissions = [{ id: 'A' }];
-        expect(deleteSubmission(submissions)('A')).toBe(true);
+        expect(deleteSubmission(submissions)('A')).toBe('A');
     });
-    it('returns false when it cant find submission to delete', (): void => {
+    it('returns undefined when it cant find submission to delete', (): void => {
         const submissions = [{ id: 'A' }];
-        expect(deleteSubmission(submissions)('C')).toBe(false);
+        expect(() => deleteSubmission(submissions)('C')).toThrow("can't find submission: C");
     });
 });

--- a/src/use-cases/deleteSubmission.ts
+++ b/src/use-cases/deleteSubmission.ts
@@ -1,8 +1,9 @@
-export const deleteSubmission = (submissions): ((id) => boolean) => (id): boolean => {
+export const deleteSubmission = (submissions): ((id) => string | undefined) => (id): string | undefined => {
     const submissionIndex = submissions.findIndex(submission => submission.id === id);
     if (submissionIndex !== -1) {
         submissions = submissions.splice(submissionIndex, 1);
-        return true;
+        return id;
     }
-    return false;
+
+    throw new Error("can't find submission: " + id);
 };


### PR DESCRIPTION
To make client state management easier we return the submission id when deleting