### PR TITLE
typedef file changes to bring inline with submission

### DIFF
--- a/src/mock-graphql/typeDefs.ts
+++ b/src/mock-graphql/typeDefs.ts
@@ -15,12 +15,12 @@ export const typeDefs = gql`
         id: ID!
         updated: String!
         articleType: String!
-        author: AuthorDetails!
-        manuscriptFile: File
+        author: AuthorDetails
         manuscriptDetails: ManuscriptDetails
-        supportingFiles: [File]
-        coverLetter: String
-        suggestions: [String]
+        files: FileDetails
+        editors: EditorDetails
+        disclosure: DisclosureDetails
+        suggestions: [Suggestion]
     }
 
     type AuthorDetails {
@@ -29,14 +29,26 @@ export const typeDefs = gql`
         email: String!
         institution: String!
     }
-
+    type FileDetails {
+        manuscriptFile: File
+        supportingFiles: [File]
+        coverLetter: String
+    }
+    type EditorDetails {
+        opposedSeniorEditorsReason: String
+        opposedReviewingEditorsReason: String
+        opposedReviewersReason: String
+    }
+    type DisclosureDetails {
+        submitterSignature: String
+        disclosureConsent: Boolean
+    }
     input AuthorDetailsInput {
         firstName: String!
         lastName: String!
         email: String!
         institution: String!
     }
-
     type ManuscriptDetails {
         title: String
         subjects: [String]
@@ -44,7 +56,10 @@ export const typeDefs = gql`
         previouslySubmitted: [String!]
         cosubmission: [String!]
     }
-
+    type Suggestion {
+        fieldName: String!
+        value: String!
+    }
     input ManuscriptDetailsInput {
         title: String
         subjects: [String]

--- a/src/mock-graphql/typeDefs.ts
+++ b/src/mock-graphql/typeDefs.ts
@@ -87,7 +87,7 @@ export const typeDefs = gql`
         changeSubmissionTitle(id: ID!, title: String!): Submission!
         deleteSubmission(id: ID!): ID
         saveAuthorPage(id: ID!, details: AuthorDetailsInput!): Submission!
-        saveFilesPage(id: ID!, coverLetter: String!): Submission!
+        saveFilesPage(id: ID!, coverLetter: String): Submission!
         saveDetailsPage(id: ID!, details: ManuscriptDetailsInput!): Submission!
         uploadManuscript(id: ID!, file: Upload!, fileSize: Int!): Submission!
     }

--- a/src/use-cases/saveFilesPage.test.ts
+++ b/src/use-cases/saveFilesPage.test.ts
@@ -7,25 +7,24 @@ describe('saveFilesPage', (): void => {
         const submissions = [
             {
                 id: v4(),
-                coverLetter: '',
+                files: { coverLetter: '' },
             },
         ];
 
         const badRequest = (): object => saveFilesPage(submissions)(null, { id: submissionId, coverLetter: 'test' });
         expect(badRequest).toThrow();
     });
-
     it('save coverLetter of a submission', (): void => {
         const submissionId = v4();
         const submissions = [
             {
                 id: submissionId,
-                coverLetter: '',
+                files: { coverLetter: '' },
             },
         ];
-        expect(submissions[0].coverLetter).toBe('');
+        expect(submissions[0].files.coverLetter).toBe('');
         saveFilesPage(submissions)(null, { id: submissionId, coverLetter: 'test' });
         expect(submissions).toHaveLength(1);
-        expect(submissions[0].coverLetter).toBe('test');
+        expect(submissions[0].files.coverLetter).toBe('test');
     });
 });

--- a/src/use-cases/saveFilesPage.ts
+++ b/src/use-cases/saveFilesPage.ts
@@ -1,9 +1,9 @@
 export const saveFilesPage = (
-    submissions: Array<{ id: string; coverLetter: string }>,
+    submissions: Array<{ id: string; files: { coverLetter: string } }>,
 ): ((_, { id, coverLetter }) => {}) => (_, { id, coverLetter = '' }): {} => {
     const submissionIndex = submissions.findIndex(submission => submission.id === id);
     if (submissionIndex !== -1) {
-        submissions[submissionIndex].coverLetter = coverLetter;
+        submissions[submissionIndex].files.coverLetter = coverLetter;
         return submissions[submissionIndex];
     }
     throw new Error('could not find submission with id: ' + id);

--- a/src/use-cases/uploadManuscript.test.ts
+++ b/src/use-cases/uploadManuscript.test.ts
@@ -5,7 +5,7 @@ describe('uploadManuscript', (): void => {
         const submissions = [{ id: 'A' }, { id: 'B' }];
         const submission = await uploadManuscript(submissions)(null, { id: 'A', fileSize: 40, file: {} });
         expect(submission).toBeTruthy();
-        expect(submission.manuscriptFile?.url).toBe('http://localhost/bucket/name.pdf');
+        expect(submission.files?.manuscriptFile?.url).toBe('http://localhost/bucket/name.pdf');
     });
 
     it('Throws if submission does not exist', async (): Promise<void> => {
@@ -16,8 +16,8 @@ describe('uploadManuscript', (): void => {
     });
 
     it('adds the manuscriptFile to the in memory submission object', async (): Promise<void> => {
-        const submissions: { id: string; manuscriptFile?: {} }[] = [{ id: 'A' }];
+        const submissions: { id: string; files?: { manuscriptFile?: {} } }[] = [{ id: 'A' }];
         await uploadManuscript(submissions)(null, { id: 'A', fileSize: 40, file: {} });
-        expect(submissions[0].manuscriptFile).toBeDefined();
+        expect(submissions[0].files?.manuscriptFile).toBeDefined();
     });
 });

--- a/src/use-cases/uploadManuscript.ts
+++ b/src/use-cases/uploadManuscript.ts
@@ -28,7 +28,9 @@ type Submission = {
     articleType: string;
     status: string;
     createdBy: string;
-    manuscriptFile?: File;
+    files: {
+        manuscriptFile?: File;
+    };
 };
 
 export const uploadManuscript = (submissions): ((_, { id, file, fileSize }) => Promise<Submission>) => async (
@@ -48,7 +50,9 @@ export const uploadManuscript = (submissions): ((_, { id, file, fileSize }) => P
             size: 1000,
             status: FileStatus.UPLOADED,
         };
-        submissions[submissionIndex].manuscriptFile = manuscriptFile;
+        submissions[submissionIndex].files
+            ? (submissions[submissionIndex].files.manuscriptFile = manuscriptFile)
+            : (submissions[submissionIndex].files = { manuscriptFile });
         return submissions[submissionIndex];
     }
 


### PR DESCRIPTION
Closes #https://github.com/libero/reviewer/issues/656

Brings typeDefs inline with reviewer-submission and converts the Submission properties to the new nested data model.