### PR TITLE
Rename submission property details to manuscriptDetails

### DIFF
--- a/src/use-cases/saveDetailsPage.test.ts
+++ b/src/use-cases/saveDetailsPage.test.ts
@@ -7,7 +7,7 @@ describe('saveDetailsPage', (): void => {
         const submissions = [
             {
                 id: v4(),
-                details: {
+                manuscriptDetails: {
                     title: '',
                     subjects: [],
                     previouslyDiscussed: '',
@@ -29,12 +29,12 @@ describe('saveDetailsPage', (): void => {
         expect(badRequest).toThrow();
     });
 
-    it('save author details of a submission', (): void => {
+    it('save manuscript details of a submission', (): void => {
         const submissionId = v4();
         const submissions = [
             {
                 id: submissionId,
-                details: {
+                manuscriptDetails: {
                     title: '',
                     subjects: [],
                     previouslyDiscussed: '',
@@ -54,13 +54,13 @@ describe('saveDetailsPage', (): void => {
 
         saveDetailsPage(submissions)(null, { id: submissionId, details: input });
         expect(submissions).toHaveLength(1);
-        expect(submissions[0].details.title).toBe('test');
-        expect(submissions[0].details.subjects).toHaveLength(1);
-        expect(submissions[0].details.subjects[0]).toBe('Cancer Biology');
-        expect(submissions[0].details.previouslyDiscussed).toBe('no');
-        expect(submissions[0].details.previouslySubmitted).toHaveLength(1);
-        expect(submissions[0].details.previouslySubmitted[0]).toBe('not-sure');
-        expect(submissions[0].details.cosubmisssion).toHaveLength(1);
-        expect(submissions[0].details.cosubmisssion[0]).toBe('certainly');
+        expect(submissions[0].manuscriptDetails.title).toBe('test');
+        expect(submissions[0].manuscriptDetails.subjects).toHaveLength(1);
+        expect(submissions[0].manuscriptDetails.subjects[0]).toBe('Cancer Biology');
+        expect(submissions[0].manuscriptDetails.previouslyDiscussed).toBe('no');
+        expect(submissions[0].manuscriptDetails.previouslySubmitted).toHaveLength(1);
+        expect(submissions[0].manuscriptDetails.previouslySubmitted[0]).toBe('not-sure');
+        expect(submissions[0].manuscriptDetails.cosubmisssion).toHaveLength(1);
+        expect(submissions[0].manuscriptDetails.cosubmisssion[0]).toBe('certainly');
     });
 });

--- a/src/use-cases/saveDetailsPage.ts
+++ b/src/use-cases/saveDetailsPage.ts
@@ -1,10 +1,9 @@
-export const saveDetailsPage = (submissions: Array<{ id: string; details: {} }>): ((_, { id, details }) => {}) => (
-    _,
-    { id, details = {} },
-): {} => {
+export const saveDetailsPage = (
+    submissions: Array<{ id: string; manuscriptDetails: {} }>,
+): ((_, { id, details }) => {}) => (_, { id, details = {} }): {} => {
     const submissionIndex = submissions.findIndex(submission => submission.id === id);
     if (submissionIndex !== -1) {
-        submissions[submissionIndex].details = details;
+        submissions[submissionIndex].manuscriptDetails = details;
         return submissions[submissionIndex];
     }
     throw new Error('could not find submission with id: ' + id);


### PR DESCRIPTION
This fixes a bug with Submission object not matching expected GQL schema.